### PR TITLE
Use the JDK from the hosted runners

### DIFF
--- a/.github/workflows/mac-windows.yml
+++ b/.github/workflows/mac-windows.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-java@v3.6.0
       with:
         java-version: 11
-        distribution: adopt
+        distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v3
       with:
@@ -77,7 +77,7 @@ jobs:
       uses: actions/setup-java@v3.6.0
       with:
         java-version: 11
-        distribution: adopt
+        distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v3
       id: m2cache # note the cache id, see below for cache-hit

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v3.6.0
       with:
         java-version: 11
-        distribution: adopt
+        distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v3
       with:
@@ -71,7 +71,7 @@ jobs:
       uses: actions/setup-java@v3.6.0
       with:
         java-version: ${{ matrix.java }}
-        distribution: adopt
+        distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v3
       id: m2cache # note the cache id, see below for cache-hit


### PR DESCRIPTION
This way, we save some time avoiding downloading and installing JDK